### PR TITLE
Pre-loading inputless literals into the graph and skipping a few functionn calls

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -505,6 +505,10 @@ Builder.prototype._createInputMappings = function () {
   }
 }
 
+/**
+ * Moves input literals into an object to be copied from when
+ * _run() is called (and skips function unnecessary function calls
+  */
 Builder.prototype._prepareInputlessLiterals = function () {
   for (var key in this._compiled.nodes) {
     var node = this._compiled.nodes[key]
@@ -514,7 +518,6 @@ Builder.prototype._prepareInputlessLiterals = function () {
         var outputNode = this._compiled.nodes[node.outputNodes[i]]
         outputNode.numUniqueInputs--
       }
-      node.outputNodes = []
     }
   }
 }
@@ -574,7 +577,7 @@ Builder.prototype._findStartingNodes = function () {
   var nonStartingNodes = []
   for (var key in this._compiled.nodes) {
     var node = this._compiled.nodes[key]
-    if (node.numUniqueInputs === 0) {
+    if (node.numUniqueInputs === 0 && !node.literalPromise) {
       this._compiled.startingNodes.push(key)
     }
   }

--- a/test/dot.js
+++ b/test/dot.js
@@ -22,19 +22,19 @@ exports.testDotGraph = function (test) {
 
   var expectedOutput = 'digraph G {\n  "builderOutput-DOT_TEST_1 (BUILDER OUTPUT)" [ color = "green" ];\n' +
     '  "name-toUpper-peerGroup1 (name-toUpper)" [ color = "orange" ];\n' +
-    '  "name-fromLiteral-peerGroup1" [ color = "blue" ];\n' +
+    '  "name-fromLiteral-peerGroup1 (name-fromLiteral)" [ color = "blue" ];\n' +
     '  "name-toLower-peerGroup1 (name-toLower)" [ color = "orange" ];\n' +
     '  "req" [ color = "red" ];\n' +
     '  "req.query" [ color = "red" ];\n' +
     '  "req.query.name" [ color = "red" ];\n' +
-    '  "age-peerGroup1" [ color = "orange" ];\n' +
-    '  "name-fromLiteral-peerGroup1" -> "name-toUpper-peerGroup1 (name-toUpper)";\n' +
+    '  "age-peerGroup1 (age)" [ color = "orange" ];\n' +
+    '  "name-fromLiteral-peerGroup1 (name-fromLiteral)" -> "name-toUpper-peerGroup1 (name-toUpper)";\n' +
     '  "name-toUpper-peerGroup1 (name-toUpper)" -> "builderOutput-DOT_TEST_1 (BUILDER OUTPUT)";\n' +
     '  "req" -> "req.query";\n' +
     '  "req.query" -> "req.query.name";\n' +
     '  "req.query.name" -> "name-toLower-peerGroup1 (name-toLower)";\n' +
     '  "name-toLower-peerGroup1 (name-toLower)" -> "builderOutput-DOT_TEST_1 (BUILDER OUTPUT)";\n' +
-    '  "age-peerGroup1" -> "builderOutput-DOT_TEST_1 (BUILDER OUTPUT)";\n}\n'
+    '  "age-peerGroup1 (age)" -> "builderOutput-DOT_TEST_1 (BUILDER OUTPUT)";\n}\n'
 
   test.equal(dotOutput, expectedOutput, "Graph dot output should be predictable")
   test.done()


### PR DESCRIPTION
Hello sho, jon, 

Please review the following commits I made in branch 'azulus-literals'.

9d129a1584b8e2305b833d2042ade0a01753880a (2013-03-13 12:09:55 -0700)
Pre-loading input literals into the graph and skipping a few function calls

R=sho
R=jon
