### PR TITLE
Updating README to fix precedence issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Getting started
 To get started with **shepherd**, you need to create a `Graph`. A `Graph` is a registry of all of the things you want to be able to do (units of work). First, instantiate the Graph:
 
 ```javascript
-var Graph = require("shepherd").Graph
-  , graph = new Graph
+var shepherd = require("shepherd")
+var graph = new shepherd.Graph()
 ```
 
 Next, you need to add some nodes to the `Graph` which perform said units of work. Let's add 2 nodes to the Graph:
@@ -53,8 +53,8 @@ What is the Graph really?
 The `Graph` in shepherd is the place where you put all the things your application is able to do. Before you add any nodes to a `Graph`, you'll need to make sure to instantiate it first:
 
 ```javascript
-var Graph = require("shepherd").Graph
-  , graph = new Graph
+var shepherd = require("shepherd")
+var graph = new shepherd.Graph()
 ```
 
 Adding nodes to the Graph


### PR DESCRIPTION
Hello jeremy, 

Please review the following commits I made in branch 'vinny-readme-update'.

I was playing with the examples in the README to get a sense of 
Shepherd and I ran into the following issue:

``` javascript
var graph = new require('shepherd').Graph
```

This would result in the following crash:

```
TypeError: Object function Graph() {
...
}
has no method 'add'
    at Object.<anonymous> (/Users/vinny/code/shepherd_test/test.js:6:7)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:901:3
```

This was reproduced in both node v0.8.20 and v0.10.5.

For this reason, I've updated to the following:

``` javascript
var Graph = require('shepherd').Graph
  , graph = new Graph
```

This works fine.

R=jeremy
