### PR TITLE
Switching function hashing to stay consistent across restarts

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -666,13 +666,13 @@ Builder.prototype._findStartingNodes = function () {
 }
 
 /**
- * Get the hash for a node handler function
+ * Get the original graph node name for a node handler function
  *
  * @param  {function} fn the function
  * @param  {string} nodeName the name of the node
- * @return {string} the hash for the function (likely another node name in this case)
+ * @return {string} the original graph node for the function (likely another node name in this case)
  */
-Builder.prototype._getFunctionHash = function (fn, nodeName) {
+Builder.prototype._getOriginNode = function (fn, nodeName) {
   var hash = oid.hash(fn)
   if (!this._functionHashOriginalNodes[hash]) {
     this._functionHashOriginalNodes[hash] = nodeName
@@ -711,7 +711,7 @@ Builder.prototype._generateHashesForNode = function (nodeName) {
   }
 
   // compute the function hash and a unique index for this node if caching is disabled
-  node.fnHash = this._getFunctionHash(node.fn, node.originalName)
+  node.fnOriginNode = this._getOriginNode(node.fn, node.originalName)
   if (node.cacheDisabled) {
     node._hashIdx = this._uniqueHashIdx++
   }
@@ -719,33 +719,33 @@ Builder.prototype._generateHashesForNode = function (nodeName) {
   // build the complete hash
   var foundHashes = {}
   var ignoredErrorLen = Object.keys(node.ignoredErrors).length
-  node.completeHash = crypto.createHash('md5').update(JSON.stringify(node, function createCompleteHash(key, val) {
+  node.completeHash = createMD5Hash(JSON.stringify(node, function createCompleteHash(key, val) {
     if (!key) return val
     if (IGNORED_HASH_NODES[key] & HASH_TYPE_COMPLETE) return undefined
 
     if (typeof val == 'object' && val != null) {
-      val = crypto.createHash('md5').update(JSON.stringify(val)).digest('hex')
+      val = createMD5Hash(JSON.stringify(val))
       if (typeof val === 'object' && foundHashes[val]) return hash
       foundHashes[val] = true
     }
 
     return val
-  })).digest('hex')
+  }))
 
   // build the non-silent hash
   foundHashes = {}
-  node.nonSilentHash = crypto.createHash('md5').update(JSON.stringify(node, function createNonSilentHash(key, val) {
+  node.nonSilentHash = createMD5Hash(JSON.stringify(node, function createNonSilentHash(key, val) {
     if (!key) return val
     if (IGNORED_HASH_NODES[key] & HASH_TYPE_NON_SILENT) return undefined
 
     if (typeof val == 'object' && val != null) {
-      val = crypto.createHash('md5').update(JSON.stringify(val)).digest('hex')
+      val = createMD5Hash(JSON.stringify(val))
       if (typeof val === 'object' && foundHashes[val]) return hash
       foundHashes[val] = true
     }
 
     return val
-  })).digest('hex')
+  }))
 
   return node
 }
@@ -924,7 +924,7 @@ Builder.prototype._reduceNodeOverhead = function () {
     delete node.completeHash
     delete node._hashIdx
     delete node.silentOutputs
-    delete node.fnHash
+    delete node.fnOriginNode
     delete node.silentHashes
     delete node.argHashes
   }
@@ -2187,4 +2187,14 @@ function createOutputMapper(argNames) {
 function deepFreeze(data) {
   if (typeof data == 'object') utils.deepFreeze(data)
   return data
+}
+
+/**
+ * Utility function to generate an md5 hash for an input string
+ *
+ * @param  {string} str the input string
+ * @return {string} the generated hash
+ */
+function createMD5Hash(str) {
+  return crypto.createHash('md5').update(str).digest('hex')
 }


### PR DESCRIPTION
This could potentially pave the way for disk-caching of compiled graphs, etc.

Hello nicks, eford, 

Please review the following commits I made in branch 'azulus-compilerCache'.

d35341b00e99a60b20b5f1ae842db0e1e57a8967 (2013-05-20 10:19:53 -0700)
Flipped node hashing to stay consistent across multiple compiles

R=nicks
R=eford
