### PR TITLE
Stopped stringifying references to literals. Using references to their promises instead

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -57,7 +57,7 @@ var IGNORED_HASH_NODES = {
   fn: HASH_TYPE_ALL,
   requiredFields: HASH_TYPE_ALL,
   outputNodes: HASH_TYPE_ALL,
-  literalPromise: HASH_TYPE_ALL,
+  literalValue: HASH_TYPE_ALL,
   numUniqueInputs: HASH_TYPE_ALL,
   isArrayWrapper: HASH_TYPE_ALL,
   isSubgraph: HASH_TYPE_ALL,
@@ -727,8 +727,12 @@ Builder.prototype._generateHashesForNode = function (nodeName) {
     if (keyHashVisibility & HASH_TYPE_ALL == HASH_TYPE_ALL) continue
     var val = node[key]
 
-    // if the val is an object, stringify it instead
-    if (typeof val == 'object' && val != null) {
+    if (key == 'literalPromise') {
+      // literal promises are a special case, we only care about their reference
+      val = oid.hash(val)
+
+    } else if (typeof val == 'object' && val != null) {
+      // if the val is an object, stringify it instead
       val = createHash(JSON.stringify(val))
     }
 


### PR DESCRIPTION
Hello nicks, eford1, 

Please review the following commits I made in branch 'azulus-compilerCache'.

3e0b5dd38fb84dc9d409146c39e758284b2c3fdb (2013-05-21 15:35:08 -0700)
Applying changes

R=nicks
R=eford1
