### PR TITLE
Convert two getNodeInfo functions to using a new class"

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,6 +51,20 @@ function NodeInfo(sourceName, targetName) {
 
 
 /**
+ * @param {string} arg The arg name for the input node.
+ * @param {string} nodeName The node name to provide to the arg.
+ * @constructor
+ */
+function NodeArgInfo(arg, nodeName) {
+  /** @type {string} */
+  this.arg = arg
+
+  /** @type {string} */
+  this.nodeName = nodeName
+}
+
+
+/**
  * Deep clone an object
  *
  * @param {Object} the object to clone
@@ -165,25 +179,16 @@ function swapNodeRoot(nodeName, newRoot) {
 function getNodeInfoFromModifier(graph, modifier, modifiedNode) {
   if (typeof modifier === 'function') {
     // modifier is an anonymous function that takes one arg
-    return {
-      arg: 'val',
-      nodeName: graph.addAnonymous(modifiedNode, modifier, ['val'])
-    }
+    return new NodeArgInfo('val', graph.addAnonymous(modifiedNode, modifier, ['val']))
   }
 
   var inputPair = getInputPair(modifier)
   if (inputPair.length == 1) {
     // input is just a node name, deduce the field name from the modified node
-    return {
-      arg: getNodeShortName(modifiedNode),
-      nodeName: inputPair[0]
-    }
+    return new NodeArgInfo(getNodeShortName(modifiedNode), inputPair[0])
   } else {
     // modifier is an object of modifier name to value.
-    return {
-      arg: inputPair[1],
-      nodeName: inputPair[0]
-    }
+    return new NodeArgInfo(inputPair[1], inputPair[0])
   }
 }
 
@@ -226,10 +231,7 @@ function getNodeInfoFromInput(graph, input) {
   var inputPair = getInputPair(input)
   if (inputPair.length == 1) {
     // input is just a node name, deduce the field name and return a map of field to node
-    return {
-      arg: getNodeShortName(inputPair[0]),
-      nodeName: inputPair[0]
-    }
+    return new NodeArgInfo(getNodeShortName(inputPair[0]), inputPair[0])
 
   } else {
     var key = inputPair[0]
@@ -243,10 +245,7 @@ function getNodeInfoFromInput(graph, input) {
       nodeName = graph.addAnonymous(key, fn)
     }
 
-    return {
-      arg: key,
-      nodeName: nodeName
-    }
+    return new NodeArgInfo(key, nodeName)
   }
 }
 


### PR DESCRIPTION
Hello @nicks, 

It looked like `getNodeInfoFromInput` returned the same schema, so I converted that as well.

Please review the following commits I made in branch 'kylehardgrave-return-class'.

eda0cfddccfde474686f1cb3d42ab85a65b29f8c (2013-06-05 17:04:19 -0700)
Have getNodeInfoFromModifier also use the new class object

ad7b410b08990cc00d7d312d827f3a4e08a8dfbf (2013-06-05 16:59:52 -0700)
Have getNodeInfoFromInput return a class object

R=nicks
