### PR TITLE
Clean up hash generation. Properties that are only needed for hashing shouldn't be stored on the node permanently. Explicitly enumerate what we use for the hash, rather than consuming everything and blacklisting.

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -40,38 +40,9 @@ var PROFILE_BUCKET_SIZE = 60 * 1000
 // store the last 30 minutes of profile buckets
 var MAX_PROFILE_BUCKETS = 30
 
-// bits for the different hash types
-var HASH_TYPE_COMPLETE = 1
-var HASH_TYPE_NON_SILENT = 2
-var HASH_TYPE_ALL = HASH_TYPE_COMPLETE | HASH_TYPE_NON_SILENT
-
 // hash of magic strings that never name real nodes.
 var MAGIC_NODE_NAMES = {
   _requiredFields: true
-}
-
-// list of fields to ignore from the hasher
-var IGNORED_HASH_NODES = {
-  _graph: HASH_TYPE_ALL,
-  originalName: HASH_TYPE_ALL,
-  newName: HASH_TYPE_ALL,
-  inputs: HASH_TYPE_ALL,
-  fn: HASH_TYPE_ALL,
-  requiredFields: HASH_TYPE_ALL,
-  outputNodes: HASH_TYPE_ALL,
-  literalValue: HASH_TYPE_ALL,
-  numUniqueInputs: HASH_TYPE_ALL,
-  cacheDisabled: HASH_TYPE_ALL,
-  isConditional: HASH_TYPE_ALL,
-  isSilent: HASH_TYPE_ALL,
-  silentOutputs: HASH_TYPE_ALL,
-  silentInputs: HASH_TYPE_ALL,
-  argInputs: HASH_TYPE_ALL,
-  completeHash: HASH_TYPE_ALL,
-  nonSilentHash: HASH_TYPE_ALL,
-  implicitInputs: HASH_TYPE_ALL,
-
-  silentHashes: HASH_TYPE_NON_SILENT
 }
 
 // default handler function to allow the compile step to finish without yelling,
@@ -103,7 +74,8 @@ function CompiledNode(
   this.implicitInputs = []
   this.ignoredErrors = CompiledNode._buildIgnoredErrors(def, inputs, argInputs)
   this.fn = def.getFunction()
-  this.cacheDisabled = !!def.isCacheDisabled(),
+  this.cacheDisabled = !!def.isCacheDisabled()
+  this.isSilent = false
   this.silentOutputs = {}
   this.hasGettersEnabled = def.hasGettersEnabled()
   this.requiredFields = []
@@ -138,6 +110,115 @@ CompiledNode.prototype.isSubgraph = function () {
 /** @return {boolean} */
 CompiledNode.prototype.isArrayWrapper = function () {
   return this.fn === this._graph.argsToArray
+}
+
+/**
+ * Generate the hashes for this node and its inputs, and store them on the node.
+ *
+ * This needs to be done after we've generated all the compiled nodes, because
+ * the hash of one node will depend recursively on the hashes of its inputs.
+ *
+ * @param {Object.<string, CompiledNode>} nodes A map of all the node inputs.
+ * @param {Object.<string, string>} fnOriginNames A memoization of function hashes to their original name.
+ * @param {function(): number} idProvider A unique ID provider.
+ */
+CompiledNode.prototype.generateHashes = function (nodes, fnOriginNames, idProvider) {
+  if (this.completeHash) return
+
+  // Find hashes for all inputs.
+  var argHashes = {}
+  var silentHashes = {}
+  var keys = Object.keys(this.inputs).sort()
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i]
+    var inputRoot = utils.getNodeRootName(this.inputs[key])
+    var inputSuffix = this.inputs[key].substr(inputRoot.length)
+
+    var compiledInput = nodes[inputRoot]
+    if (compiledInput) {
+      compiledInput.generateHashes(nodes, fnOriginNames, idProvider)
+    }
+    var inputHashes = compiledInput || {completeHash: inputRoot, nonSilentHash: inputRoot}
+    if (this.silentInputs.indexOf(key) !== -1){
+      silentHashes[key] = inputHashes.completeHash + inputSuffix
+    }
+    var argIndex = this.argInputs.indexOf(key)
+    if (argIndex !== -1) {
+      argHashes[key] = {idx: argIndex, hash: inputHashes.nonSilentHash + inputSuffix}
+    }
+  }
+
+  // Start with a hash of all inputs and outputs.
+  var hashBuilder = new NodeHashBuilder()
+      .add(silentHashes, true)
+      .add(argHashes)
+      .add(oid.hash(this.literalPromise))
+
+  // compute the function hash, and mix that in.
+  var fnHash = oid.hash(this.fn)
+  var fnOriginName = fnOriginNames[fnHash]
+  if (!fnOriginName) {
+    fnOriginName = fnOriginNames[fnHash] = this.originalName
+  }
+  hashBuilder.add(fnOriginName)
+
+  // If results caching is disabled, add a unique index for this node.
+  if (this.cacheDisabled) {
+    hashBuilder.add(idProvider())
+  }
+
+  this.completeHash = hashBuilder.buildCompleteHash()
+  this.nonSilentHash = hashBuilder.buildNonSilentHash()
+}
+
+/**
+ * Builds up hashes for a CompiledNode.
+ *
+ * We need two distinct types of hatches:
+ * 1) A "complete" hash that includes silent inputs, which we use for
+ *    de-duping nodes.
+ * 2) A "non-silent" hash that only includes visible inputs and outputs,
+ *    which we use for storing intermediate results in GraphResults.
+ *
+ * @constructor
+ */
+function NodeHashBuilder() {
+  this._completeHashVals = []
+  this._nonSilentHashVals = []
+}
+
+/**
+ * @param {Object|number|string} val A value to add to the hash.
+ * @param {boolean} opt_silent Whether this value represents a silent input.
+ * @return {NodeHashBuilder} this, for easy chaining.
+ */
+NodeHashBuilder.prototype.add = function (val, opt_silent) {
+  if (typeof val == 'object' && val != null) {
+    // if the val is an object, stringify it instead
+    val = createHash(JSON.stringify(val))
+  }
+
+  var valType = typeof val
+  if (valType !== 'string' && valType !== 'number' && val != null) {
+    throw new Error('invalid hash val')
+  }
+
+  this._completeHashVals.push(val)
+  if (!opt_silent) {
+    this._nonSilentHashVals.push(val)
+  }
+  return this
+}
+
+/** @return {string} The complete hash. */
+NodeHashBuilder.prototype.buildCompleteHash = function () {
+  // using a | delimiter for now for simplicity (it works well for all inputs to the hashing currently)
+  return createHash(this._completeHashVals.join('|'))
+}
+
+/** @return {string} A hash of visible inputs/outputs. */
+NodeHashBuilder.prototype.buildNonSilentHash = function () {
+  return createHash(this._nonSilentHashVals.join('|'))
 }
 
 
@@ -192,7 +273,6 @@ function Builder(graph, name, config) {
   this._builds = {}
   this._silentBuilds = {}
   this._resolvers = {}
-  this._uniqueHashIdx = 1
 
   this._handlers = {
     'pre': [],
@@ -786,93 +866,19 @@ Builder.prototype._findStartingNodes = function () {
 }
 
 /**
- * Get the original graph node name for a node handler function
- *
- * @param  {function} fn the function
- * @param  {string} nodeName the name of the node
- * @return {string} the original graph node for the function (likely another node name in this case)
- */
-Builder.prototype._getOriginNode = function (fn, nodeName) {
-  var hash = oid.hash(fn)
-  if (!this._functionHashOriginalNodes[hash]) {
-    this._functionHashOriginalNodes[hash] = nodeName
-  }
-  return this._functionHashOriginalNodes[hash]
-}
-
-/**
- * Produce hashes for a specified node by gathering hashes of its own handler
- * function as well as the hashes of dependency nodes and hashes of any node
- * names which aren't nodes in the graph (may be provided as run time inputs)
- *
- * @param {string} nodeName the name of the node
- */
-Builder.prototype._generateHashesForNode = function (nodeName) {
-  var node = this._compiled.nodes[nodeName]
-  if (!node) return {completeHash: nodeName, nonSilentHash: nodeName}
-  if (node.completeHash) return node
-
-  // recursively set this node to cacheDisabled if needed
-  node.argHashes = {}
-  node.silentHashes = {}
-  var keys = Object.keys(node.inputs).sort()
-  for (var i = 0; i < keys.length; i++) {
-    var key = keys[i]
-    var nodeRoot = utils.getNodeRootName(node.inputs[key])
-    var nodeSuffix = node.inputs[key].substr(nodeRoot.length)
-    var nodeHashes = this._generateHashesForNode(nodeRoot)
-    if (node.silentInputs.indexOf(key) !== -1){
-      node.silentHashes[key] = nodeHashes.completeHash + nodeSuffix
-    }
-    var argIndex = node.argInputs.indexOf(key)
-    if (argIndex !== -1) {
-      node.argHashes[key] = {idx: argIndex, hash: nodeHashes.nonSilentHash + nodeSuffix}
-    }
-  }
-
-  // compute the function hash and a unique index for this node if caching is disabled
-  node.fnOriginNode = this._getOriginNode(node.fn, node.originalName)
-  if (node.cacheDisabled) {
-    node._hashIdx = this._uniqueHashIdx++
-  }
-
-  // build the hashes
-  var completeHashVals = [], nonSilentHashVals = []
-
-  for (var key in node) {
-    var keyHashVisibility = IGNORED_HASH_NODES[key]
-
-    // if the key is marked as being invisible to both hashes, ignore it
-    if (keyHashVisibility & HASH_TYPE_ALL == HASH_TYPE_ALL) continue
-    var val = node[key]
-
-    if (key == 'literalPromise') {
-      // literal promises are a special case, we only care about their reference
-      val = oid.hash(val)
-
-    } else if (typeof val == 'object' && val != null) {
-      // if the val is an object, stringify it instead
-      val = createHash(JSON.stringify(val))
-    }
-
-    // add to the applicable hash inputs
-    if (!(keyHashVisibility & HASH_TYPE_COMPLETE)) completeHashVals.push(val)
-    if (!(keyHashVisibility & HASH_TYPE_NON_SILENT)) nonSilentHashVals.push(val)
-  }
-
-  // using a | delimiter for now for simplicity (it works well for all inputs to the hashing currently)
-  node.completeHash = createHash(completeHashVals.join('|'))
-  node.nonSilentHash = createHash(nonSilentHashVals.join('|'))
-
-  return node
-}
-
-/**
  * Generate hashes for every node in the graph
  */
 Builder.prototype._generateHashesForNodes = function () {
+  var originalNames = {}
+  var uniqueId = 0
+  var idProvider = function () {
+    return ++uniqueId
+  }
   for (var key in this._compiled.nodes) {
-    this._generateHashesForNode(key)
+    var node = this._compiled.nodes[key]
+    if (node) {
+      node.generateHashes(this._compiled.nodes, originalNames, idProvider)
+    }
   }
 }
 
@@ -1036,11 +1042,7 @@ Builder.prototype._reduceNodeOverhead = function () {
     delete node.allInputs
     delete node.isSilent
     delete node.completeHash
-    delete node._hashIdx
     delete node.silentOutputs
-    delete node.fnOriginNode
-    delete node.silentHashes
-    delete node.argHashes
   }
 }
 


### PR DESCRIPTION
Hello @eford1, 

Please review the following commits I made in branch 'nick-compiled-node3'.

8f120b48dfaf77edbaab944738c3b300ce196c17 (2013-07-10 12:18:40 -0400)
Clean up hash generation. 
Properties that are only needed for hashing shouldn't be stored on the node permanently. 
Explicitly enumerate what we use for the hash, rather than consuming everything and blacklisting.

R=@eford1
