### PR TITLE
Fix parameter checking for subgraphs

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -672,7 +672,8 @@ Builder.prototype._validateBuilder = function (runInputs) {
 
       // Check nodes for correctly declared parameters
       if (this._config.enforceMatchingParams &&
-          nodeName.indexOf(utils.NODE_PREFIX_BUILDER_OUTPUT) !== 0) {
+          nodeName.indexOf(utils.NODE_PREFIX_BUILDER_OUTPUT) !== 0 &&
+          !compiledNode.isSubgraph()) {
 
         var actualParams = utils.parseFnParams(compiledNode.fn)
 


### PR DESCRIPTION
Hello @nicks, 

Please review the following commits I made in branch 'kyle-simplify-tests'.

41fe0e9b84da2bc9854e8b0b0427e24d96201bdc (2013-07-12 16:37:11 -0700)
Don't parameter-check graph.subgraph

0c20c4e69717b71845a0ecb1c5e8e0ce907a10a6 (2013-07-12 16:32:29 -0700)
Simplify failure tests

R=@nicks
