### PR TITLE
Graphviz is a real shepherd dependency, not a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     , "url": "https://github.com/Obvious/shepherd.git"
   }
   , "dependencies": {
+    "graphviz": "0.0.8",
     "kew": "0.1.7",
     "oid": "0.5.0",
     "typ": "0.6.3",
     "xxhash": "0.1.3"
   }
   , "devDependencies": {
-        "graphviz": "0.0.8",
         "nodeunit": "0.7.4",
         "nodeunitq": "0.0.2"
     }


### PR DESCRIPTION
Hello anybody, 

Please review the following commits I made in branch 'nick-graphviz'.

7ed004a0f647d4a1013179039c723af42ffdc84b (2013-07-22 10:46:26 -0400)
Graphviz is a real shepherd dependency, not a devDependency

R=anybody
