### PR TITLE
Remove unused Builder._resolve() function

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -1749,18 +1749,6 @@ Builder.prototype._compilePeers = function (ownerName, depManager, nodeInputs, n
 }
 
 /**
- * Creates a promise which will return the value of a node as generated
- * by the graph
- *
- * @param {Object} data the current calling context
- * @param {string} nodeName
- * @return {Object} val
- */
-Builder.prototype._resolve = function (data, nodeName) {
-  return this._getResolver(nodeName)(data)
-}
-
-/**
  * Read in a type error message and either throw an error or warn
  * @param  {string} enforceTypes the level at which to enforce typing
  * @param  {string} err the error message


### PR DESCRIPTION
Hello @nicks, 

Please review the following commits I made in branch 'kyle-jank'.

c1a9345c2900fd7f42031630598ac44dda50269c (2013-07-29 11:12:52 -0700)
Remove unused Builder._resolve() function

R=@nicks
