### PR TITLE
Abstract out duplicate resolver code

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -1989,14 +1989,17 @@ Builder.prototype._getErrorHandler = function (nodeName) {
   }
 }
 
+
 /**
- * Get the resolver for a literal
+ * Generate the resolver for a node given a method to extract the value
  *
  * @param {string} nodeName
- * @return {function(Object)} returns a promise which will resolve
- *     when this node has completed resolving
+ * @param {function(CompiledNode, Array.<NodeResponseGetter|Object>) : Promise} resolveNodeFn
+ *     The function used to determine how to extract the node value.
+ * @return {function(GraphResults)} A function that resolves the node given
+ *     the GraphResults so far.
  */
-Builder.prototype._getLiteralResolver = function (nodeName) {
+Builder.prototype._genResolver = function (nodeName, resolveNodeFn) {
   var node = this._compiled.nodes[nodeName]
 
   var onSuccess = this._getSuccessHandler(nodeName)
@@ -2005,105 +2008,7 @@ Builder.prototype._getLiteralResolver = function (nodeName) {
   var validateQuietInputs = this._getQuietInputValidator(nodeName)
   var validateArgumentInputs = this._getArgumentInputValidator(nodeName)
 
-  return function literalResolver(data) {
-    var err
-    var args = []
-
-    if (validateQuietInputs) err = validateQuietInputs(data)
-    if (validateArgumentInputs && !err) err = validateArgumentInputs(data, args)
-
-    return (err ? Q.reject(err) : node.literalPromise)
-      .setContext(data)
-      .then(onSuccess)
-      .fail(onError)
-      .then(onComplete)
-      .clearContext()
-  }
-}
-
-/**
- * Get the resolver for a subgraph
- *
- * @param {string} nodeName
- * @return {function(Object)} returns a promise which will resolve
- *     when this node has completed resolving
- */
-Builder.prototype._getSubgraphResolver = function (nodeName) {
-  var node = this._compiled.nodes[nodeName]
-
-  var onSuccess = this._getSuccessHandler(nodeName)
-  var onError = this._getErrorHandler(nodeName)
-  var onComplete = this._getCompleteHandler(nodeName)
-  var validateQuietInputs = this._getQuietInputValidator(nodeName)
-  var validateArgumentInputs = this._getArgumentInputValidator(nodeName)
-
-  return function subgraphResolver(data) {
-    var err
-    var args = []
-
-    if (validateQuietInputs) err = validateQuietInputs(data)
-    if (validateArgumentInputs && !err) err = validateArgumentInputs(data, args)
-
-    return (err ? Q.reject(err) : Q.resolve(args[args.length - 1]))
-      .setContext(data)
-      .then(onSuccess)
-      .fail(onError)
-      .then(onComplete)
-      .clearContext()
-  }
-}
-
-/**
- * Get the resolver for an array wrapper
- *
- * @param {string} nodeName
- * @return {function(Object)} returns a promise which will resolve
- *     when this node has completed resolving
- */
-Builder.prototype._getArrayResolver = function (nodeName) {
-  var node = this._compiled.nodes[nodeName]
-
-  var onSuccess = this._getSuccessHandler(nodeName)
-  var onError = this._getErrorHandler(nodeName)
-  var onComplete = this._getCompleteHandler(nodeName)
-  var validateQuietInputs = this._getQuietInputValidator(nodeName)
-  var validateArgumentInputs = this._getArgumentInputValidator(nodeName)
-
-  return function arrayResolver(data) {
-    var err
-    var args = []
-
-    if (validateQuietInputs) err = validateQuietInputs(data)
-    if (validateArgumentInputs && !err) err = validateArgumentInputs(data, args)
-
-    return (err ? Q.reject(err) : Q.resolve(args))
-      .setContext(data)
-      .then(onSuccess)
-      .fail(onError)
-      .then(onComplete)
-      .clearContext()
-  }
-}
-
-/**
- * Get the resolver for a node without callbacks
- *
- * @param {string} nodeName
- * @return {function(Object)} returns a promise which will resolve
- *     when this node has completed resolving
- */
-Builder.prototype._getNonCallbackResolver = function (nodeName) {
-  var node = this._compiled.nodes[nodeName]
-  var config = this._config
-  var profiler = this._boundProfiler
-
-  var onSuccess = this._getSuccessHandler(nodeName)
-  var onError = this._getErrorHandler(nodeName)
-  var onComplete = this._getCompleteHandler(nodeName)
-  var validateQuietInputs = this._getQuietInputValidator(nodeName)
-  var validateArgumentInputs = this._getArgumentInputValidator(nodeName)
-
-  return function nonCallbackResolver(data) {
+  return function resolve(data) {
     var err
     var args = []
 
@@ -2112,16 +2017,14 @@ Builder.prototype._getNonCallbackResolver = function (nodeName) {
 
     if (!err && data._shouldProfile) data._startTimes[nodeName] = Date.now()
 
-    var promise = data.getHashedResultPromise(node)
-    if (!err && !promise) {
-      try {
-        promise = Q.resolve(node.fn.apply(null, args))
-      } catch (e) {
-        err = e
-      }
+    var promise
+    if (err) {
+      promise = Q.reject(err)
+    } else {
+      promise = data.getHashedResultPromise(node) || resolveNodeFn(node, args)
     }
 
-    return (err ? Q.reject(err) : promise)
+    promise
       .setContext(data)
       .then(onSuccess)
       .fail(onError)
@@ -2131,52 +2034,68 @@ Builder.prototype._getNonCallbackResolver = function (nodeName) {
 }
 
 /**
- * Get the resolver for a node with callbacks
+ * Resolve a literal
  *
- * @param {string} nodeName
- * @return {function(Object)} returns a promise which will resolve
- *     when this node has completed resolving
+ * @param {CompiledNode} node The node to resolve
+ * @param {Array.<NodeResponseGetter|Object>} args The argument inputs
+ * @return {Promise.<Object>} The result of the resolved node
  */
-Builder.prototype._getCallbackResolver = function (nodeName) {
-  var node = this._compiled.nodes[nodeName]
-  var config = this._config
-  var profiler = this._boundProfiler
+Builder.prototype._resolveLiteral = function (node, args) {
+  return node.literalPromise
+}
 
-  var onSuccess = this._getSuccessHandler(nodeName)
-  var onError = this._getErrorHandler(nodeName)
-  var onComplete = this._getCompleteHandler(nodeName)
-  var validateQuietInputs = this._getQuietInputValidator(nodeName)
-  var validateArgumentInputs = this._getArgumentInputValidator(nodeName)
+/**
+ * Resolve a subgraph
+ *
+ * @param {CompiledNode} node The node to resolve
+ * @param {Array.<NodeResponseGetter|Object>} args The argument inputs
+ * @return {Promise.<Object>} The result of the resolved node
+ */
+Builder.prototype._resolveSubgraph = function (node, args) {
+  return Q.resolve(args[args.length - 1])
+}
 
-  return function callbackResolver(data) {
-    var err
-    var args = []
+/**
+ * Resolve an array wrapper
+ *
+ * @param {CompiledNode} node The node to resolve
+ * @param {Array.<NodeResponseGetter|Object>} args The argument inputs
+ * @return {Promise.<Object>} The result of the resolved node
+ */
+Builder.prototype._resolveArray = function (node, args) {
+  return Q.resolve(args)
+}
 
-    if (validateQuietInputs) err = validateQuietInputs(data)
-    if (validateArgumentInputs && !err) err = validateArgumentInputs(data, args)
+/**
+ * Resolve a node without callbacks
+ *
+ * @param {CompiledNode} node The node to resolve
+ * @param {Array.<NodeResponseGetter|Object>} args The argument inputs
+ * @return {Promise.<Object>} The result of the resolved node
+ */
+Builder.prototype._resolveNonCallback = function (node, args) {
+  try {
+    return Q.resolve(node.fn.apply(null, args))
+  } catch (e) {
+    return Q.reject(e)
+  }
+}
 
-    if (!err && data._shouldProfile) data._startTimes[nodeName] = Date.now()
-
-    var promise = data.getHashedResultPromise(node)
-
-    // node with callbacks
-    if (!err && !promise) {
-      try {
-        var defer = Q.defer()
-        args.push(defer.makeNodeResolver())
-        var response = node.fn.apply(null, args)
-        promise = typeof response == 'undefined' ? defer.promise : Q.resolve(response)
-      } catch (e) {
-        promise = Q.reject(e)
-      }
-    }
-
-    return (err ? Q.reject(err) : promise)
-      .setContext(data)
-      .then(onSuccess)
-      .fail(onError)
-      .then(onComplete)
-      .clearContext()
+/**
+ * Resolve a node with callbacks
+ *
+ * @param {CompiledNode} node The node to resolve
+ * @param {Array.<NodeResponseGetter|Object>} args The argument inputs
+ * @return {Promise.<Object>} The result of the resolved node
+ */
+Builder.prototype._resolveCallback = function (node, args) {
+  try {
+    var defer = Q.defer()
+    args.push(defer.makeNodeResolver())
+    var response = node.fn.apply(null, args)
+    return typeof response == 'undefined' ? defer.promise : Q.resolve(response)
+  } catch (e) {
+    return Q.reject(e)
   }
 }
 
@@ -2197,21 +2116,20 @@ Builder.prototype._getResolver = function (nodeName) {
   var node = this._compiled.nodes[nodeName]
   var config = this._config
 
+  var nodeResolverFn
   if (node.literalPromise) {
-    return this._resolvers[nodeName] = this._getLiteralResolver(nodeName)
-
+    nodeResolverFn = this._resolveLiteral
   } else if (node.isSubgraph()) {
-    return this._resolvers[nodeName] = this._getSubgraphResolver(nodeName)
-
+    nodeResolverFn = this._resolveSubgraph
   } else if (node.isArrayWrapper()) {
-    return this._resolvers[nodeName] = this._getArrayResolver(nodeName)
-
+    nodeResolverFn = this._resolveArray
   } else if (!config.useCallbacks) {
-    return this._resolvers[nodeName] = this._getNonCallbackResolver(nodeName)
-
+    nodeResolverFn = this._resolveNonCallback
   } else {
-    return this._resolvers[nodeName] = this._getCallbackResolver(nodeName)
+    nodeResolverFn = this._resolveCallback
   }
+
+  return this._resolvers[nodeName] = this._genResolver(nodeName, nodeResolverFn)
 }
 
 module.exports = Builder


### PR DESCRIPTION
Hello @nicks, @eford1,

This is a change that will help with removing promises by simplifying one of the chief places where they're used, but I wanted to make it separately for clarity. I commented at two places in the commit where the code actually does something different, but I don't think they should be a problem. I tested this against medium2 as well and everything checks out.

Please review the following commits I made in branch 'kyle-cleanup-resolver-code'.

95fea3d5a65b13ce0ee8c06165534fd0ec6bfc6c (2013-07-29 18:15:11 -0700)
Abstract out duplicate resolver code

R=@nicks
R=@eford1
