### PR TITLE
Remove ignoreErrors(), which was only used for conditionals

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -80,7 +80,6 @@ function CompiledNode(
 
   this.originalName = originalNodeName
   this.newName = newNodeName
-  this.ignoredErrors = CompiledNode._buildIgnoredErrors(def, inputs, importantInputs)
   this.fn = def.getFunction()
   this.cacheDisabled = !!def.isCacheDisabled()
   this.hasGettersEnabled = def.hasGettersEnabled()
@@ -169,9 +168,6 @@ CompiledNode.prototype.addImplicitImportantInput = function (dep) {
   this.inputs[dep] = dep
   this._importantInputs.push(dep)
   this._implicitInputs.push(dep)
-  if (this.ignoredErrors[utils.DYNAMIC_NODE_REF]) {
-    this.ignoredErrors[dep] = true
-  }
 }
 
 /**
@@ -407,26 +403,6 @@ NodeHashBuilder.prototype.buildCompleteHash = function () {
 /** @return {string} A hash of visible inputs/outputs. */
 NodeHashBuilder.prototype.buildNonImportantHash = function () {
   return createHash(this._nonImportantHashVals.join('|'))
-}
-
-
-/** @return {Object.<string, boolean>} */
-CompiledNode._buildIgnoredErrors = function (def, inputs, importantInputs) {
-  // keep track of any nodes that are allowed to fail
-  var ignoredErrors = def.getIgnoredErrors()
-  var ignoredErrorMap = {}
-  for (i = 0; i < ignoredErrors.length; i++) {
-    var ignoredNodeName = ignoredErrors[i]
-    if (ignoredNodeName == '_dynamic') {
-      ignoredErrorMap[ignoredNodeName] = true
-    } else {
-      var inputNodeName = inputs[ignoredNodeName]
-      if (importantInputs.indexOf(ignoredNodeName) === -1)
-        throw new Error("Only important nodes may have their errors ignored")
-      ignoredErrorMap[inputNodeName] = true
-    }
-  }
-  return ignoredErrorMap
 }
 
 
@@ -699,21 +675,6 @@ Builder.prototype._deduplicateNodes = function () {
       remappedNode = remappedNodes[utils.getNodeRootName(inputName)]
       if (remappedNode) {
         node.inputs[inputKey] = utils.swapNodeRoot(inputName, remappedNode.newName)
-      }
-    }
-  }
-
-  // remap any ignored error references
-  for (key in this._compiled.nodes) {
-    node = this._compiled.nodes[key]
-
-    // node might be ignoring errors from deduplicated nodes
-    for (var nodeName in node.ignoredErrors) {
-      var nodeRoot = utils.getNodeRootName(nodeName)
-      var inputNode = this._compiled.nodes[nodeRoot]
-      if (inputNode && hashNodes[inputNode.completeHash] !== inputNode) {
-        delete node.ignoredErrors[nodeName]
-        node.ignoredErrors[utils.swapNodeRoot(nodeName, hashNodes[inputNode.completeHash].newName)] = true
       }
     }
   }
@@ -1956,7 +1917,7 @@ Builder.prototype._getCompleteHandler = function (nodeName) {
  *
  * @param {string} nodeName
  * @return {function(Object)} the important input validator which will return an error
- *     if a quiet input has failed that shouldn't be ignored
+ *     if a quiet input has failed
  */
 Builder.prototype._getQuietInputValidator = function (nodeName) {
   var node = this._compiled.nodes[nodeName]
@@ -1970,9 +1931,9 @@ Builder.prototype._getQuietInputValidator = function (nodeName) {
     for (var i = 0; i < quietInputNames.length && !err; i++) {
       var inputName = node.inputs[quietInputNames[i]]
       var inputRootName = utils.getNodeRootName(inputName)
-      if (!node.ignoredErrors[inputRootName] && data._errors[inputRootName]) {
+      if (data._errors[inputRootName]) {
         err = data._errors[inputRootName]
-      } else if (!node.ignoredErrors[inputRootName] && inputName != inputRootName) {
+      } else if (inputName != inputRootName) {
         try {
           var val = getChildGetter(inputName)(data.getResult(inputRootName, node))
         } catch (e) {
@@ -1989,9 +1950,9 @@ Builder.prototype._getQuietInputValidator = function (nodeName) {
  * Create a non-important input validator for a graph node
  *
  * @param {string} nodeName
- * @return {function(Object, Array)} the non-important input validator which will return an error
- *     if a important input has failed that shouldn't be ignored. Modifies the array of arguments
- *     in place for consumption by the resolvers
+ * @return {function(Object, Array)} the non-important input validator which
+ *     will return an error if a important input has failed. Modifies the array
+ *     of arguments in place for consumption by the resolvers
  */
 Builder.prototype._getArgumentInputValidator = function (nodeName) {
   var node = this._compiled.nodes[nodeName]

--- a/lib/NodeDefinition.js
+++ b/lib/NodeDefinition.js
@@ -34,32 +34,6 @@ function NodeDefinition(graph, name) {
   this._cacheDisabled = false
   this._fn = null
   this._hasGettersEnabled = false
-  this._ignoredErrors = []
-}
-
-/**
- * Get the list of nodes that this node should ignore errors
- * for
- *
- * @return {Array.<string>}
- */
-NodeDefinition.prototype.getIgnoredErrors = function () {
-  return this._ignoredErrors
-}
-
-/**
- * Ignore errors from a given set of input nodes
- *
- * @param {Array.<string>|string} var_args a variable length
- *     list of node names or an array of node names
- * @return {NodeDefinition} the current instance
- */
-NodeDefinition.prototype.ignoreErrors = function (var_args) {
-  var_args = Array.isArray(var_args) ? var_args : Array.prototype.slice.call(arguments, 0)
-  for (var i = 0; i < var_args.length; i++) {
-    this._ignoredErrors.push(var_args[i])
-  }
-  return this
 }
 
 /**
@@ -161,7 +135,6 @@ NodeDefinition.prototype.clone = function (graph) {
   def._modifiers = clone(this._modifiers)
   def._fn = this._fn
   def._hasGettersEnabled = this._hasGettersEnabled
-  def._ignoredErrors = clone(this._ignoredErrors)
   def._cacheDisabled = clone(this._cacheDisabled)
 
   return def


### PR DESCRIPTION
Hello @kylehardgrave, 

Please review the following commits I made in branch 'nick-ignore-erros'.

b4a949190329e65c339ca7501097eed0f12329e3 (2013-08-01 18:35:27 -0400)
Remove ignoreErrors(), which was only used for conditionals

R=@kylehardgrave
