### PR TITLE
Don't use Promises for chaining Shepherd result handlers

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -2049,19 +2049,36 @@ Builder.prototype._genResolver = function (nodeName, resolveNodeFn) {
 
     if (!err && data._shouldProfile) data._startTimes[nodeName] = Date.now()
 
-    var promise
-    if (err) {
-      promise = Q.reject(err)
-    } else {
-      promise = data.getHashedResultPromise(node) || resolveNodeFn(node, args)
+    var result
+    if (!err) {
+      try {
+        result = data.getHashedResult(node) || resolveNodeFn(node, args)
+      } catch (e) {
+        err = e
+      }
     }
 
-    promise
-      .setContext(data)
-      .then(onSuccess)
-      .fail(onError)
-      .then(onComplete)
-      .clearContext()
+    // TODO(kyle): Change this once kew has been updated
+    // if (Q.isPromise(result)) {
+    if (result && result._isPromise) {
+      Q.resolve(result)
+        .setContext(data)
+        .then(onSuccess)
+        .fail(onError)
+        .then(onComplete)
+        .clearContext()
+      return
+    }
+
+    // onSuccess throws if there's a Shepherd type error
+    try {
+      if (!err) onSuccess(result, data)
+    } catch (e) {
+      err = e
+    }
+
+    if (err) onError(err, data)
+    onComplete(result, data)
   }
 }
 
@@ -2081,10 +2098,10 @@ Builder.prototype._resolveLiteral = function (node, args) {
  *
  * @param {CompiledNode} node The node to resolve
  * @param {Array.<NodeResponseGetter|Object>} args The argument inputs
- * @return {Promise.<Object>} The result of the resolved node
+ * @return {Object} The result of the resolved node
  */
 Builder.prototype._resolveSubgraph = function (node, args) {
-  return Q.resolve(args[args.length - 1])
+  return args[args.length - 1]
 }
 
 /**
@@ -2092,10 +2109,10 @@ Builder.prototype._resolveSubgraph = function (node, args) {
  *
  * @param {CompiledNode} node The node to resolve
  * @param {Array.<NodeResponseGetter|Object>} args The argument inputs
- * @return {Promise.<Object>} The result of the resolved node
+ * @return {Object} The result of the resolved node
  */
 Builder.prototype._resolveArray = function (node, args) {
-  return Q.resolve(args)
+  return args
 }
 
 /**
@@ -2103,14 +2120,10 @@ Builder.prototype._resolveArray = function (node, args) {
  *
  * @param {CompiledNode} node The node to resolve
  * @param {Array.<NodeResponseGetter|Object>} args The argument inputs
- * @return {Promise.<Object>} The result of the resolved node
+ * @return {Object} The result of the resolved node
  */
 Builder.prototype._resolveNonCallback = function (node, args) {
-  try {
-    return Q.resolve(node.fn.apply(null, args))
-  } catch (e) {
-    return Q.reject(e)
-  }
+  return node.fn.apply(null, args)
 }
 
 /**
@@ -2118,17 +2131,13 @@ Builder.prototype._resolveNonCallback = function (node, args) {
  *
  * @param {CompiledNode} node The node to resolve
  * @param {Array.<NodeResponseGetter|Object>} args The argument inputs
- * @return {Promise.<Object>} The result of the resolved node
+ * @return {Promise.<Object>|Object} The result of the resolved node
  */
 Builder.prototype._resolveCallback = function (node, args) {
-  try {
-    var defer = Q.defer()
-    args.push(defer.makeNodeResolver())
-    var response = node.fn.apply(null, args)
-    return typeof response == 'undefined' ? defer.promise : Q.resolve(response)
-  } catch (e) {
-    return Q.reject(e)
-  }
+  var defer = Q.defer()
+  args.push(defer.makeNodeResolver())
+  var response = node.fn.apply(null, args)
+  return typeof response == 'undefined' ? defer.promise : response
 }
 
 /**

--- a/lib/Graph.js
+++ b/lib/Graph.js
@@ -213,6 +213,7 @@ Graph.prototype.validator = function (regex, msg) {
  */
 Graph.prototype.subgraph = function (var_args) {
   var data = typeof arguments[arguments.length - 1] == 'function' ? arguments[arguments.length - 2] : arguments[arguments.length - 1]
+  // Wrap undefined in a promise so we know it's there
   return typeof data !== 'undefined' ? data : Q.resolve(undefined)
 }
 
@@ -577,6 +578,7 @@ module.exports = Graph
 function makeLiteralHandler(val) {
   val = val && val._literal ? val._literal : val
 
+  // Wrap undefined in a promise so we know it's there
   var handlerVal = typeof val == 'undefined' ? Q.resolve(val) : val
   var fn = function () {
     return handlerVal

--- a/lib/GraphResults.js
+++ b/lib/GraphResults.js
@@ -122,8 +122,7 @@ GraphResults.prototype._recordInjection = function (nodeName, requester) {
 /**
  * @param {string} nodeName
  * @param {CompiledNode} requester
- * @return {Promise} A promise with the value resolved or the error rejected.
- *     null if there's no cached result.
+ * @return {Object} The resolved value or null if there's no cached result.
  */
 GraphResults.prototype.getResult = function (nodeName, requester) {
   this._recordInjection(nodeName, requester)
@@ -133,13 +132,12 @@ GraphResults.prototype.getResult = function (nodeName, requester) {
 /**
  * @param {CompiledNode} node
  * @param {CompiledNode} requester
- * @return {Promise} A promise with the value resolved or the error rejected.
- *     null if there's no cached result.
+ * @return {Object} The resolved value or null if there's no cached result.
  */
-GraphResults.prototype.getHashedResultPromise = function (node, requester) {
+GraphResults.prototype.getHashedResult = function (node, requester) {
   if (this._hashedValues[node.nonImportantHash]) {
     this._recordInjection(node.newName, requester)
-    return Q.resolve(this._hashedValues[node.nonImportantHash])
+    return this._hashedValues[node.nonImportantHash]
   }
   return null
 }


### PR DESCRIPTION
Hello @nicks, 

Tested against medium2 unit and functional tests.

Please review the following commits I made in branch 'kyle-callbacks'.

018f01f751c41a0a03fb25440bded1fd9b66739f (2013-08-01 16:58:51 -0700)
Remove promises as method of chaining handlers

R=@nicks
