### PR TITLE
Make it so that handler functions default to Graph#subgraph if left unspecified

### DIFF
--- a/lib/Graph.js
+++ b/lib/Graph.js
@@ -442,6 +442,7 @@ Graph.prototype.add = function (name, fn, deps, builder) {
     } else {
       node = this._nodeDefinitions[name] = new NodeDefinition(this, name)
     }
+    if (typeof fn === 'undefined') fn = this.subgraph
     if (fn) node.fn(typeof fn !== 'function' ? this.literal(fn) : fn)
   }
   node.setScope(this._state.scope)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shepherd",
   "description": "asynchronous dependency injection for node.js",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "homepage": "https://github.com/Obvious/shepherd",
   "authors": [
     "Jeremy Stanley <jeremy@obvious.com> (https://github.com/azulus)",

--- a/test/add.js
+++ b/test/add.js
@@ -115,35 +115,20 @@ builder.add(function testForceAdd(test) {
     })
 })
 
-// test that handlers are required for nodes
-builder.add(function testMissingNodesGraph(test) {
-  this.graph.add('testFn')
+// test that missing handlers are interpreted as Graph#subgraph
+builder.add(function testMissingNodeHandler(test) {
+  this.graph.add('square')
+    .args('x')
+    .fn(function (x) { return x*x } )
 
-  try {
-    this.graph.newBuilder()
-      .builds('testFn')
-      .compile()
-    test.fail('Functions without callbacks should throw errors')
-  } catch (e) {
-    test.equal(e.message.indexOf('requires a callback') > 0, true,
-               'Functions without callbacks should throw different errors: ' + e)
-  }
-  test.done()
-})
-
-// test that handlers are required for nodes
-builder.add(function testMissingNodesBuilder(test) {
   this.graph.add('testFn')
+    .builds('square').using({x: 4})
 
   return this.graph.newBuilder()
     .builds('testFn')
     .run()
-    .then(function () {
-      test.fail('Functions without callbacks should throw errors')
-    })
-    .fail(function (e) {
-      test.equal(e.message.indexOf('requires a callback') > 0, true,
-                 'Functions without callbacks should throw different errors: ' + e)
+    .then(function (data) {
+      test.equal(data['testFn'], 16, "A missing function should be interpreted as Graph#subgraph")
     })
 })
 


### PR DESCRIPTION
Hello @nicks, 

Please review the following commits I made in branch 'sho-syntax'.

This is to allow the following syntax:

``` js
// New syntax
graph.add('square')
  .args('x')
  .builds('multiply').using({x: 'args.x', y: 'args.x'})

// Old syntax
graph.add('square', graph.subgraph, ['x'])
  .builds('multiply').using({x: 'args.x', y: 'args.x'})
```

7ad3e6bc6a40e5694bd7ef3af276c0ae8b132f17 (2013-08-28 11:24:55 -0700)
Make it so that handler functions default to Graph#subgraph if left unspecified

R=@nicks
