### PR TITLE
Add a syntax for injecting args, to complement the new shepherd syntax

### DIFF
--- a/lib/NodeDefinition.js
+++ b/lib/NodeDefinition.js
@@ -485,9 +485,47 @@ NodeDefinition.prototype.unless = function(field) {
 
 /**
  * Set the handler function for this node
- *
  */
 NodeDefinition.prototype.fn = function (fn) {
+  this._fn = fn
+  return this
+}
+
+/**
+ * Set the handler function for this node, but inject based on parameter name instead
+ * of based on order.
+ *
+ * If the parameters can't be found, this will throw an error.
+ *
+ * @param {!Function} fn
+ */
+NodeDefinition.prototype.inject = function (fn) {
+  var paramNames = utils.parseFnParams(fn)
+
+  var shortArgsNames = []
+  var i = 0
+  for (i = 0; i < this._args.length; i++) {
+    shortArgsNames.push(utils.getNodeShortName(this._args[i].aliasRealName))
+  }
+
+  // Sort the arguments  so that the parameters get injected in the
+  // right order.
+  var newArgs = []
+  for (i = 0; i < paramNames.length; i++) {
+    var idx = shortArgsNames.indexOf(paramNames[i])
+    if (idx === -1) {
+      throw new Error('No injector found for parameter: ' + paramNames[i])
+    }
+
+    newArgs.push(this._args[idx])
+    this._args.splice(idx, 1)
+    shortArgsNames.splice(idx, 1)
+  }
+
+  // Push any args that are not included.
+  newArgs.push.apply(newArgs, this._args)
+  this._args = newArgs
+
   this._fn = fn
   return this
 }


### PR DESCRIPTION
Hello @skuwamoto, 

Please review the following commits I made in branch 'nick-injectors'.

30566b213a229f021affc7146857d24519016be8 (2013-09-12 19:27:43 -0400)
Add a syntax for injecting args, to complement the new shepherd syntax

R=@skuwamoto
