### PR TITLE
Allow clients to specify placeholders when mapping keys for injection

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -913,18 +913,24 @@ Builder.prototype.createInjector = function (fn) {
  * Extracts the argument names from a function.
  *
  * @param {Function} fn
+ * @param {Array.<string>} placeholders parameter names which don't
+ *   have to match because they will be supplied later.
  * @return {Array.<string>}
  */
-Builder.prototype.mapOutputKeysToArgs = function (fn) {
+Builder.prototype.mapOutputKeysToArgs = function (fn, placeholders) {
   var paramNames = utils.parseFnParams(fn)
   var outputNames = this._outputNode.getOutputNodeNames()
   var shortOutputNames = outputNames.map(utils.getNodeInjectorName)
   var argNames = []
+  placeholders = placeholders || []
 
   for (var i = 0; i < paramNames.length; i++) {
     var idx = shortOutputNames.indexOf(paramNames[i])
     if (idx === -1) {
-      throw new Error('No injector found for parameter: ' + paramNames[i])
+      var placeholderIdx = placeholders.indexOf(paramNames[i])
+      if (placeholderIdx === -1) {
+        throw new Error('No injector found for parameter: ' + paramNames[i])
+      }
     }
     argNames.push(outputNames[idx])
   }

--- a/lib/NodeInstance.js
+++ b/lib/NodeInstance.js
@@ -80,6 +80,14 @@ NodeInstance.prototype.createInjector = function () {
 }
 
 /**
+ * Proxy function which can be used to chain mapOutputKeysToArgs() requests back
+ * to the builder
+ */
+NodeInstance.prototype.mapOutputKeysToArgs = function () {
+  return this._builder.mapOutputKeysToArgs.apply(this._builder, arguments)
+}
+
+/**
  * Proxy function which can be used to chain getCompiledNodes() requests back
  * to the builder
  */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shepherd",
   "description": "asynchronous dependency injection for node.js",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "homepage": "https://github.com/Obvious/shepherd",
   "authors": [
     "Jeremy Stanley <jeremy@obvious.com> (https://github.com/azulus)",

--- a/test/builder.js
+++ b/test/builder.js
@@ -290,6 +290,21 @@ builder.add(function testCreateInjectorBadParams(test) {
   test.done()
 })
 
+builder.add(function testCreateInjectorWithPlaceholders(test) {
+  graph.add('num', function (n) {
+    return n
+  }, ['n'])
+
+  var builder = graph.newBuilder()
+    .builds({'one': 'num'}).using({n: 1})
+    .builds({'two-fromNum': 'num'}).using({n: 2})
+    .builds({'three': 'num'}).using({n: 3})
+
+  var handler = builder.mapOutputKeysToArgs(function (three, one, two, four, five) {}, ['four', 'five'])
+
+  test.done()
+})
+
 builder.add(function testInject(test) {
   var nums = []
   graph.add('num', function (n) {


### PR DESCRIPTION
Hello @nicks, @tessr, 

Please review the following commits I made in branch 'jamie-output-mapping-placeholders'.

f1c503d2242492b069e9b517651a414796309da3 (2014-01-27 14:44:21 -0800)
Allow clients to specify placeholders when mapping keys for injection

R=@nicks
R=@tessr
