### PR TITLE
Remove kew Contexts from shepherd

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -807,10 +807,8 @@ Builder.prototype.run = function (input, callback, callbackScope) {
   // handle callbacks
   if (callback) {
     promise
-    .setContext({scope: callbackScope, callback: callback})
-    .then(onRunSuccess)
-    .fail(onRunFailure)
-    .clearContext()
+    .thenBound(onRunSuccess, null, {scope: callbackScope, callback: callback}))
+    .failBound(onRunFailure, null, {scope: callbackScope, callback: callback}))
   }
 
   return promise
@@ -1999,7 +1997,7 @@ Builder.prototype._getSuccessHandler = function (nodeName) {
   var isArray = typeof type != 'undefined' && Array.isArray(type)
   if (isArray) type = type[0]
 
-  return function onSuccess(response, data) {
+  return function onSuccess(data, response) {
     if (enforceTypes) {
       if (typeof type == 'undefined') {
         // types are required
@@ -2071,7 +2069,7 @@ Builder.prototype._getCompleteHandler = function (nodeName) {
     resolvers[outputNodeName] = this._getResolver(outputNodeName)
   }
 
-  return function onComplete(response, data) {
+  return function onComplete(data, response) {
     if (node.isOutput) {
       data.resolveOutputNode(nodeName)
       return
@@ -2199,7 +2197,7 @@ Builder.prototype._getArgumentInputValidator = function (nodeName) {
  */
 Builder.prototype._getErrorHandler = function (nodeName) {
   var node = this._compiled.nodes[nodeName]
-  return function onError(e, data) {
+  return function onError(data, e) {
     if (!e.graphInfo) {
       e.graphInfo = data.getDebugContext(node)
     }
@@ -2257,23 +2255,21 @@ Builder.prototype._genResolver = function (nodeName, resolveNodeFn) {
     // if (Q.isPromise(result)) {
     if (result && result._isPromise) {
       Q.resolve(result)
-        .setContext(data)
-        .then(onSuccess)
-        .fail(onError)
-        .then(onComplete)
-        .clearContext()
+        .thenBound(onSuccess, null, data))
+        .failBound(onError, null, data))
+        .thenBound(onComplete, null, data))
       return
     }
 
     // onSuccess throws if there's a Shepherd type error
     try {
-      if (!err) onSuccess(result, data)
+      if (!err) onSuccess(data, result)
     } catch (e) {
       err = e
     }
 
-    if (err) onError(err, data)
-    onComplete(result, data)
+    if (err) onError(data, err)
+    onComplete(data, result)
   }
 }
 
@@ -2391,7 +2387,7 @@ function handleTypeError(enforceTypes, err) {
  * @param {{scope: Object, callback: function((Error|undefined), Object)}}
  *     context the callback context
  */
-function onRunSuccess(data, context) {
+function onRunSuccess(context, data) {
   context.callback.call(context.scope, undefined, data)
 }
 
@@ -2401,7 +2397,7 @@ function onRunSuccess(data, context) {
  * @param  {Error} e the response data
  * @param  {{scope: Object, callback: function(Error, Object=)}} context the callback context
  */
-function onRunFailure(e, context) {
+function onRunFailure(context, e) {
   context.callback.call(context.scope, e)
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shepherd",
   "description": "asynchronous dependency injection for node.js",
-  "version": "2.3.2",
+  "version": "2.3.3-alpha",
   "homepage": "https://github.com/Obvious/shepherd",
   "authors": [
     "Jeremy Stanley <jeremy@obvious.com> (https://github.com/azulus)",


### PR DESCRIPTION
Hello @x-ma, @nicks, @dpup, 

Please review the following commits I made in branch 'nathan-noContext'.

346aa898c3a4d4ab118430fd0e8ca11e6a4d2844 (2014-09-25 17:39:21 -0700)
Remove kew Contexts from shepherd
They have unclear semantics and moving to asynchronous promise execution has
been causing a number of issues.  This is clearer and safer code.

R=@x-ma
R=@nicks
R=@dpup
