### PR TITLE
Upgrade to kew@0.5.0-alpha

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -2092,7 +2092,7 @@ Builder.prototype._getCompleteHandler = function (nodeName) {
 
     // if there are multiple nodes to build, build them on nextTick
     for (var i = 0; i < nextNodes.length; i++) {
-      setImmediate(data.fnWrapper(resolvers[nextNodes[i]]))
+      Q.resolve(null).then(data.fnWrapper(resolvers[nextNodes[i]]))
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shepherd",
   "description": "asynchronous dependency injection for node.js",
-  "version": "2.3.3-alpha.1",
+  "version": "2.3.3-alpha.2",
   "homepage": "https://github.com/Obvious/shepherd",
   "authors": [
     "Jeremy Stanley <jeremy@obvious.com> (https://github.com/azulus)",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "graphviz": "0.0.8",
-    "kew": "0.4.0",
+    "kew": "0.5.0-alpha",
     "oid": "0.5.0",
     "typ": "0.6.3",
     "xxhash": "0.1.3"


### PR DESCRIPTION
Hello @nicks, @x-ma, @sboora, @eford1, 

Please review the following commits I made in branch 'nathan-kew'.

c6a13195bc23f4035337901ab97ba182a4a67745 (2014-09-29 11:03:37 -0700)
Upgrade to kew@0.5.0-alpha
As part of this change, I have removed the call to setImmediate in
favor of using whatever later/nextTick function kew is.

R=@nicks
R=@x-ma
R=@sboora
R=@eford1
