### PR TITLE
Don't try to handle quiet errors

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -2224,10 +2224,10 @@ Builder.prototype._genResolver = function (nodeName, resolveNodeFn) {
   var validateArgumentInputs = this._getArgumentInputValidator(nodeName)
 
   return function resolve(data) {
-    var err
+    var err, quietErr
     var args = []
 
-    if (validateQuietInputs) err = validateQuietInputs(data)
+    if (validateQuietInputs) quietErr = err = validateQuietInputs(data)
     if (validateArgumentInputs && !err) err = validateArgumentInputs(data, args)
 
     if (!err && data._shouldProfile) data._startTimes[nodeName] = Date.now()
@@ -2241,7 +2241,7 @@ Builder.prototype._genResolver = function (nodeName, resolveNodeFn) {
       }
     }
 
-    if (err && node.errorFn) {
+    if (err && !quietErr && node.errorFn) {
       try {
         node.errorFn(err, args)
       } catch (recursiveErr) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shepherd",
   "description": "asynchronous dependency injection for node.js",
-  "version": "2.3.3-alpha.2",
+  "version": "2.3.3-alpha.3",
   "homepage": "https://github.com/Obvious/shepherd",
   "authors": [
     "Jeremy Stanley <jeremy@obvious.com> (https://github.com/azulus)",


### PR DESCRIPTION
Hello @nicks, @x-ma, 

Please review the following commits I made in branch 'nathan-deferredErr'.

0a398a756ffc1190ec67ded43afeedb9077dcca9 (2014-10-08 09:36:01 -0700)
Don't try to handle quiet errors

I was slightly wrong in my analysis, it looks like quiet errors are going to be
propogated through just about everything, including the `__deferreds` nodes (which
don't actually have any dependencies).

This is a slight semantic change since it means that error handlers will only
handle errors that happen from their nodes, not those that are propogated.

Another quick solution here is to just not re-throw the error from `handleThunkError`

R=@nicks
R=@x-ma
