### PR TITLE
Make shepherd compatible with node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.12"
+  - "0.10"
+  - "0.8"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 shepherd: asynchronous dependency injection and more!
 ==================================
 
+[![Build Status](https://travis-ci.org/Medium/shepherd.svg)](https://travis-ci.org/Medium/shepherd)
+
 **Shepherd** is a graph-based dependency resolution system, designed to simplify request pipelines that have multiple asynchronous steps. Shepherd makes it easy to split code into fine-grained, composable units.
 
 For example, a feed may draw on multiple sources of data which need to be fetched in parallel (and each may have multiple processing steps), but they may have some common dependencies. With **Shepherd**, you would break each step into a single function, which would return immediately or through a promise, and specify any direct dependencies. Once all of the components are created atomically, the `Graph` will handle when each node runs and provide you with the processed output once all steps have completed.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "shepherd",
   "description": "asynchronous dependency injection for node.js",
-  "version": "2.3.3-alpha.3",
-  "homepage": "https://github.com/Obvious/shepherd",
+  "version": "2.4.0",
+  "homepage": "https://github.com/Medium/shepherd",
   "authors": [
     "Jeremy Stanley <jeremy@obvious.com> (https://github.com/azulus)",
     "Elizabeth Ford <eford@obvious.com> (https://github.com/eford1)"
@@ -12,14 +12,14 @@
   "main": "lib/shepherd.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Obvious/shepherd.git"
+    "url": "https://github.com/Medium/shepherd.git"
   },
   "dependencies": {
     "graphviz": "0.0.8",
-    "kew": "0.5.0-alpha",
-    "oid": "0.5.0",
+    "kew": "0.5.0",
+    "oid": "1.0.0",
     "typ": "0.6.3",
-    "xxhash": "0.1.3"
+    "xxhash": "0.2.1"
   },
   "externDependencies": {
     "graphviz": "./externs/graphviz.js",
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "closure-npc": "0.1.2",
-    "nodeunit": "0.7.4",
+    "nodeunit": "0.9.0",
     "nodeunitq": "0.1.1"
   },
   "scripts": {


### PR DESCRIPTION
Hello @kylehg, 

Please review the following commits I made in branch 'nick-node12'.

40dec48f4f8bafa5f1224ac0e4404eb54d041f33 (2015-02-12 15:47:51 -0500)
Make shepherd compatible with node 0.12

R=@kylehg