### PR TITLE
remove node 0.8 build, now that it's basically unsupported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "0.12"
   - "0.10"
-  - "0.8"


### PR DESCRIPTION
Hello @nicks, 

Please review the following commits I made in branch 'nick-node'.

4de87c0084809da49e4c498fb30b3cdc4288ecb7 (2015-03-18 15:23:32 -0400)
remove node 0.8 build, now that it's basically unsupported

R=@nicks