### PR TITLE
Support injecting into single-parameter arrow functions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,6 +14,8 @@ var OUTPUT_SUFFIX_PRIVATE = '_'
 
 var NODE_NAME_RE = /^[!?+%]?[a-zA-Z_*][-a-zA-Z0-9_]*(?:[.][a-zA-Z_][a-zA-Z0-9_]*)*(?:[._](?:[0-9]+|[*]))?$/
 
+var SINGLE_PARAM_ARROW_FN_RE = /^(\w+)\s+=>/
+
 var DYNAMIC_NODE_REF = '_dynamic'
 var INPUT_ARG_PREFIX = 'args.'
 var LAZY_ARG_PREFIX = 'lazyargs.'
@@ -549,11 +551,18 @@ function parseFnParams(fn) {
     keywordIndex = ctorMatch.index
   }
 
-  var lParenIdx = fnStr.indexOf('(', keywordIndex)
+  var arrowMatch = SINGLE_PARAM_ARROW_FN_RE.exec(fnStr)
+    , lParenIdx = fnStr.indexOf('(', keywordIndex)
     , rParenIdx = fnStr.indexOf(')', keywordIndex)
     , paramsStr
     , params
     , i
+
+  // ES6 arrow functions with a single parameter don't require parentheses
+  // around the parameter, so we must handle them separately
+  if (arrowMatch) {
+    return [arrowMatch[1]]
+  }
 
   // Check for existence of parentheses
   if (lParenIdx === -1 || rParenIdx === -1) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shepherd",
   "description": "asynchronous dependency injection for node.js",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "homepage": "https://github.com/Medium/shepherd",
   "authors": [
     "Jeremy Stanley <jeremy@obvious.com> (https://github.com/azulus)",

--- a/test/testdata/arrows.js
+++ b/test/testdata/arrows.js
@@ -1,0 +1,13 @@
+'use strict'
+
+/**
+ * Arrow functions testing. Split into a separate file so that
+ * we can load it conditionally if the env supports ES6.
+ */
+
+module.exports = {
+  empty: () => something(true),
+  single: (param) => something(true),
+  singleBare: param => something(true),
+  multiple: (hot, cross, buns) => something(true),
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,6 +2,7 @@
 
 var Q = require('kew')
 var nodeunitq = require('nodeunitq')
+var semver = require('semver')
 var builder = new nodeunitq.Builder(exports)
 var utils = require('../lib/utils')
 
@@ -44,6 +45,47 @@ builder.add(function testNodeNames(test) {
   bad('req.*.*')
   bad('req.*.abc')
   bad('req*')
+
+  test.done()
+})
+
+builder.add(function testParseClassicFnParams(test) {
+  function named(one, two, three) {
+    something(true)
+  }
+
+  function single(arg) {
+    something(true)
+  }
+
+  function empty() {
+    something(true)
+  }
+
+  test.deepEqual(['one', 'two', 'three'], utils.parseFnParams(named))
+  test.deepEqual(['arg'], utils.parseFnParams(single))
+  test.deepEqual([], utils.parseFnParams(empty))
+
+  test.deepEqual(['one', 'two', 'three'], utils.parseFnParams(function (one, two, three) {
+    something(true)
+  }))
+  test.deepEqual(['arg'], utils.parseFnParams(function (arg) { something(true) }))
+  test.deepEqual([], utils.parseFnParams(function() { something(true) }))
+
+  test.done()
+})
+
+builder.add(function testParseArrowFnParams(test) {
+  'use strict'
+
+  if (semver.lt(process.version, 'v4.0.0')) return test.done()
+
+  var arrows = require('./testdata/arrows')
+
+  test.deepEqual([], utils.parseFnParams(arrows.empty))
+  test.deepEqual(['param'], utils.parseFnParams(arrows.single))
+  test.deepEqual(['param'], utils.parseFnParams(arrows.singleBare))
+  test.deepEqual(['hot', 'cross', 'buns'], utils.parseFnParams(arrows.multiple))
 
   test.done()
 })


### PR DESCRIPTION
Shepherd parses function parameter names by looking for the parentheses around the argument list. This means it's unprepared to handle single-parameter arrow functions, for which they are optional:

```js
graph.add('widget')
  .builds('factory')
  .fn(factory => factory.produce('widget', false))

// Shepherd sees 'widget', false as the param list
// as they're the first words appearing within ()
```

We're getting bitten by this in our codebase even when we add parentheses around the single parameter; the parentheses seem to be getting stripped at some point (I'd guess this is happening when Flow types are stripped).