### PR TITLE
Use 64-bit hash for hashing graph nodes instead of 32-bit

### DIFF
--- a/externs/xxhash.js
+++ b/externs/xxhash.js
@@ -3,5 +3,8 @@
 module.exports = {
   hash: function (/** Buffer */ buffer, /** number */ number) {
     return ''
+  },
+  hash64: function (/** Buffer */ buffer, /** number */ number, /** string */ encbuf) {
+    return ''
   }
 }

--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -2460,5 +2460,5 @@ function deepFreeze(data) {
  * @return {string} the generated hash
  */
 function createHash(str) {
-  return xxhash.hash(new Buffer(str), 0xCAFEBABE)
+  return xxhash.hash64(new Buffer(str), 0xBEADCAFE, 'base64')
 }


### PR DESCRIPTION
Hello @kylewm, 

Please review the following commits I made in branch 'harthur/hash64':

- **Use 64-bit hash for hashing graph nodes instead of 32-bit** (e9e8ec2879916ec3af706e81e6d1ac0ee44ce9ba)

R=@kylewm @nicks 